### PR TITLE
feat: return complete item (with data and links) on item-selected event

### DIFF
--- a/packages/furo-data-input/furo-data-reference-search.js
+++ b/packages/furo-data-input/furo-data-reference-search.js
@@ -78,8 +78,8 @@ class FuroDataReferenceSearch extends FBP(FuroInputBase(LitElement)) {
     });
 
     this._FBPAddWireHook("--itemSelected", (item) => {
-      this.field.id.value = item[this.idField];
-      this.field.display_name.value = item.display_name;
+      this.field.id.value = item.data[this.idField];
+      this.field.display_name.value = item.data.display_name;
       this._closeList();
     });
 

--- a/packages/furo-data-input/reference-search-item.js
+++ b/packages/furo-data-input/reference-search-item.js
@@ -33,7 +33,7 @@ class ReferenceSearchItem extends FBP(LitElement) {
   }
 
   injectItem(item) {
-    this._item = item.data;
+    this._item = item;
     this.requestUpdate();
   }
 
@@ -96,7 +96,7 @@ class ReferenceSearchItem extends FBP(LitElement) {
     // language=HTML
     return html`
 <div @-click="^^item-selected(_item)">
-${this._item.display_name}
+${this._item.data.display_name}
 </div>           
 `;
   }


### PR DESCRIPTION
In furo-data-reference-search instead of just returning the data the **@-item-selected** now returns complete item that was selected { data: ..., links: ... }